### PR TITLE
vm: always use Q35 machine type for x86_64

### DIFF
--- a/vm-helper/vm
+++ b/vm-helper/vm
@@ -105,14 +105,16 @@ def main():
 
     if arch == "x86_64":
         args = ["qemu-system-x86_64"]
+        args += [
+            "-machine",
+            "q35"
+        ]
         if argv.get("secureboot", False):
             args += [
                 "-drive",
                 "file=/usr/share/OVMF/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly=on",
                 "-drive",
-                "file=/usr/share/OVMF/OVMF_VARS.secboot.fd,if=pflash,format=raw,unit=1,readonly=off",
-                "-machine",
-                "q35"
+                "file=/usr/share/OVMF/OVMF_VARS.secboot.fd,if=pflash,format=raw,unit=1,readonly=off"
             ]
         elif argv.get("uefi", False):
             args += [


### PR DESCRIPTION
QEMU supports two machines types: I440FX and Q35. The latter is newer and
contains features that are not supported by the former (i.e: Secure Boot).

For some reasons, allocating UEFI memory for the kernel and initramfs are
quite slow with the I440FX chipset. This may be a bug in GRUB but there's
no reason to use a I440FX machine type, even when Secure Boot is disabled.

After all, Q35 has other nice features such as PCIe, AHCI, vIOMMU, etc. So
et's just use Q35 always for x86_64, it makes the boot faster while giving
us these Q35-only support.